### PR TITLE
Require password-change session for user deletion

### DIFF
--- a/docs/api_calls.md
+++ b/docs/api_calls.md
@@ -147,7 +147,7 @@ Delete a given user, and all data associated with their account.
 **Parameters**
 | Field           | Type   | Required | Description                                      |
 |-----------------|--------|----------|--------------------------------------------------|
-| session_id      | string | Yes      | The public ID of the login session.              |
+| session_id      | string | Yes      | The public ID of the password-change session.    |
 | request_number  | int    | Yes      | The number of this request on the login session. Must be 0 for this request type. |
 | encrypted_data  | string | Yes      | **Base64-encoded** encrypted payload (see below) |
 
@@ -161,7 +161,7 @@ Delete a given user, and all data associated with their account.
 [4 bytes: username length][username bytes]
 ```
 
-> **Note:** The request number for this request type must be 0. This means a new session must be created for user deletion.
+> **Security Note:** Account deletion requires a password-change session. The request number must be 0, meaning a new password-change session must be created specifically for deletion. This ensures the user has recently verified their password before performing this high-risk operation.
 
 **[Response Format](api_responses.md#delete-user-user)**
 

--- a/docs/api_responses.md
+++ b/docs/api_responses.md
@@ -602,6 +602,7 @@ These errors are specific to certain APIs. Only those APIs can return these erro
 | ltd00      | new_username    | 409       | [Register User](#register-user-user) [Change Username](#change-username-user) | New username already exists |
 | ltd01      | request_number  | 400       | [Delete User](#delete-user-user) | Request number must be 0 for this request type                   |
 | ltd02      | request         | 412       | [Complete Password Change](#complete-password-change-password) | Password change is not complete                     |
+| ltd03      | session_id      | 412       | [Delete User](#delete-user-user) | Account deletion requires a password-change session              |
 
 
 ### HTTP Status Codes

--- a/src/services/service_user.py
+++ b/src/services/service_user.py
@@ -1,5 +1,10 @@
 from typing import Tuple, Dict, Any
 
+from logging import getLogger
+logger = getLogger("service")
+
+from utils import DBUtilsSession, DBUtilsUser, FailureReason
+
 
 class ServiceUser():
 
@@ -13,4 +18,103 @@ class ServiceUser():
 
     @staticmethod
     def delete(data: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
-        return {}, 200
+        """
+        Delete a user account.
+
+        Security Requirements:
+        - Must use a fresh session (request_count == 0)
+        - Must use a password-change session (password_change == True)
+        """
+        # Extract session_id from request
+        session_id = data.get('session_id')
+        if not session_id:
+            logger.warning("Delete User: Missing session_id")
+            return {
+                "success": False,
+                "errors": [{
+                    "field": "session_id",
+                    "error_code": "gnr00",
+                    "error": "session_id invalid"
+                }]
+            }, 400
+
+        # Get session details
+        (
+            success, failure_reason,
+            user_id, username_hash,
+            db_session_id, session_key,
+            request_count, password_change
+        ) = DBUtilsSession.get_details(session_id)
+
+        if not success:
+            logger.warning(f"Delete User: Session not found or invalid: {failure_reason}")
+            return {
+                "success": False,
+                "errors": [{
+                    "field": "session_id",
+                    "error_code": "gnr01",
+                    "error": "session_id not found"
+                }]
+            }, 404
+
+        # Check that request_count is 0 (fresh session)
+        if request_count != 0:
+            logger.warning(f"Delete User: Session not fresh (request_count={request_count})")
+            return {
+                "success": False,
+                "errors": [{
+                    "field": "request_number",
+                    "error_code": "ltd01",
+                    "error": "Request number must be 0 for this request type"
+                }]
+            }, 400
+
+        # Check that this is a password-change session
+        if not password_change:
+            logger.warning("Delete User: Session is not a password-change session")
+            return {
+                "success": False,
+                "errors": [{
+                    "field": "session_id",
+                    "error_code": "ltd03",
+                    "error": "Account deletion requires a password-change session"
+                }]
+            }, 412
+
+        # Proceed with user deletion
+        success, failure_reason = DBUtilsUser.delete(user_id)
+
+        if not success:
+            logger.error(f"Delete User: Failed to delete user: {failure_reason}")
+            if failure_reason == FailureReason.NOT_FOUND:
+                return {
+                    "success": False,
+                    "errors": [{
+                        "field": "username",
+                        "error_code": "gnr01",
+                        "error": "username not found"
+                    }]
+                }, 404
+            elif failure_reason == FailureReason.PASSWORD_CHANGE:
+                return {
+                    "success": False,
+                    "errors": [{
+                        "field": "request",
+                        "error_code": "rqs02",
+                        "error": "Password change in progress"
+                    }]
+                }, 403
+            else:
+                return {
+                    "success": False,
+                    "errors": [{
+                        "field": "server",
+                        "error_code": "svr00",
+                        "error": "Server encountered an unexpected error"
+                    }]
+                }, 500
+
+        logger.info(f"Delete User: Successfully deleted user {username_hash[-4:]}")
+        return {
+            "success": True
+        }, 200


### PR DESCRIPTION
- Implement password-change session requirement in ServiceUser.delete()
- Add validation for session.password_change flag
- Add fresh session check (request_count == 0)
- Add new error code ltd03 for password-session requirement
- Update API documentation with security notes
- Add High-Risk Operations section to authentication.md

Fixes #34